### PR TITLE
Fix propagation of source_location information.

### DIFF
--- a/include/bugle/core/postoffice.h
+++ b/include/bugle/core/postoffice.h
@@ -56,13 +56,14 @@ class PostOffice
             const std::source_location& location = std::source_location::current()
         );
 
-        template <typename... Args>
-        void memo( std::format_string<Args...> fmt, Args&&... args );
+        void memo( 
+            const std::string& message = {},
+            const std::source_location& location = std::source_location::current()
+        );
 
-        template <typename... Args>
         void card(
-            const tags_t& tags,
-            std::format_string<Args...> fmt, Args&&... args
+            const tags_t& tags = {},
+            const std::source_location& location = std::source_location::current()
         );
 
         static PostOffice& instance();
@@ -98,23 +99,6 @@ class PostOffice
 
         static PostOfficeUPtr instance_;
 };
-
-
-template <typename... Args>
-void PostOffice::memo( std::format_string<Args...> fmt, Args&&... args ) {
-    post( std::format( fmt, std::forward<Args>( args )... ) );
-}
-
-template <typename... Args>
-void PostOffice::card(
-    const tags_t& tags,
-    std::format_string<Args...> fmt, Args&&... args )
-{
-    post(
-        std::format( fmt, std::forward<Args>( args )... ),
-        tags
-    );
-}
 
 
 }   //  ::bugle

--- a/src/core/postoffice.cpp
+++ b/src/core/postoffice.cpp
@@ -102,7 +102,7 @@ void PostOffice::memo( const std::string& message, const std::source_location& l
 ////////////////////////////////////////////////////////////////////////////////
 void PostOffice::card( const tags_t& tags, const std::source_location& location )
 {
-    post( "", tags, {}, location );
+    post( {}, tags, {}, location );
 }
 
 

--- a/src/core/postoffice.cpp
+++ b/src/core/postoffice.cpp
@@ -93,6 +93,20 @@ void PostOffice::post(
 
 
 ////////////////////////////////////////////////////////////////////////////////
+void PostOffice::memo( const std::string& message, const std::source_location& location )
+{
+    post( message, {}, {}, location );
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+void PostOffice::card( const tags_t& tags, const std::source_location& location )
+{
+    post( "", tags, {}, location );
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 int PostOffice::level( const std::thread::id& thread )
 {
 #ifdef BUGLE_ENABLE


### PR DESCRIPTION
The source location is a default parameter in PostOffice::post.

There are two convenience methods PostOffice::memo and PostOffice::card. These two convenience method propagate some parameters to PostOffice::post.
But they didn't forward std::source_location.
The result was, we got the source_location of
the convenience methods rather than the originating location.

To solve this we need to also provide the source_location in the parameter list.
But then we have a problem. In the parameter list we use a parameter pack, so we mustn't use a default parameter as well.

Decision is to keep the source_location default parameter as this is the information more important.